### PR TITLE
Use previous successful LR expansion if any

### DIFF
--- a/kiuatan/parser.pony
+++ b/kiuatan/parser.pony
@@ -369,11 +369,22 @@ actor Parser[
           _call_body(frame)
         end
       | let failure: Failure[S, D, V] =>
-        let result = Failure[S, D, V](
-          frame.rule,
-          frame.loc,
-          ErrorMsg.rule_expected(frame.rule.name, frame.loc.string()),
-          failure)
+        let result =
+          match try exp(exp.size() - 1)? end
+          | let prev_success: Success[S, D, V] =>
+            _Dbg() and _Dbg.out(
+              frame.depth, "RULE " + frame.rule.name + " @" +
+              frame.loc.string() + " = " + prev_success.string() +
+              " from previous expansion")
+            prev_success
+          else
+            Failure[S, D, V](
+              frame.rule,
+              frame.loc,
+              ErrorMsg.rule_expected(frame.rule.name, frame.loc.string()),
+              failure)
+          end
+
         if inv.size() == 1 then
           _Dbg() and _Dbg.out(
             frame.depth, "RULE " + frame.rule.name + " @" + frame.loc.string() +

--- a/kiuatan/success.pony
+++ b/kiuatan/success.pony
@@ -69,14 +69,16 @@ class box Success[
 
           match crv
           | let crv': Array[V] val if crv'.size() > 0 =>
-            match result_values'
-            | let rv: Array[V] trn =>
-              rv.append(crv')
-            else
-              let rv: Array[V] trn = Array[V]
-              rv.append(crv')
-              result_values' = consume rv
-            end
+            result_values' =
+              match consume result_values'
+              | let rv: Array[V] trn =>
+                rv.append(crv')
+                consume rv
+              else
+                let rv: Array[V] trn = Array[V]
+                rv.append(crv')
+                consume rv
+              end
           end
 
           match cb


### PR DESCRIPTION
If an LR expansion fails, but there is a previous successful one, memoize and use that one, to speed up processing.